### PR TITLE
DSM Version bump, Jenkins ci plugin , hpi and bom version change to latest…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-aggregator</artifactId>
-      <version>600.v64c23868a_132</version>
+      <version>596.v8c21c963d92d</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>4.69</version>
+    <version>4.83</version>
     <relativePath />
   </parent>
 
@@ -41,14 +41,14 @@
   </scm>
 
   <properties>
-    <jenkins.version>2.387.3</jenkins.version>
-    <hpi.compatibleSinceVersion>2.0.0</hpi.compatibleSinceVersion>
+    <jenkins.version>2.452.2</jenkins.version>
+    <hpi.compatibleSinceVersion>3.55</hpi.compatibleSinceVersion>
     <maven-hpi-plugin.disabledTestInjection>true</maven-hpi-plugin.disabledTestInjection>
 
-    <jackson.version>2.14.2</jackson.version>
-    <dsm.version>4.19.2244</dsm.version>
+    <jackson.version>2.17.1</jackson.version>
+    <dsm.version>4.29.2426</dsm.version>
     <assert.version>3.11.1</assert.version>
-    <bom.version>2357.v1043f8578392</bom.version>
+    <bom.version>3135.v6d6c1f6b_3572</bom.version>
     <workflow.version>2.5</workflow.version>
   </properties>
 
@@ -56,7 +56,7 @@
     <dependencies>
       <dependency>
         <groupId>io.jenkins.tools.bom</groupId>
-        <artifactId>bom-2.387.x</artifactId>
+        <artifactId>bom-2.452.x</artifactId>
         <version>${bom.version}</version>
         <type>pom</type>
         <scope>import</scope>
@@ -86,10 +86,25 @@
       <version>${jackson.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpclient</artifactId>
+      <version>4.5.14</version>
+    </dependency>
+    <dependency>
+    <groupId>jakarta.xml.bind</groupId>
+      <artifactId>jakarta.xml.bind-api</artifactId>
+      <version>4.0.2</version>
+    </dependency>
+<dependency>
+    <groupId>jakarta.activation</groupId>
+    <artifactId>jakarta.activation-api</artifactId>
+    <version>2.1.3</version>
+</dependency>
+    <dependency>
       <groupId>com.fortanix</groupId>
       <artifactId>sdkms-client</artifactId>
       <version>${dsm.version}</version>
-      <exclusions>
+      <!--exclusions>
         <exclusion>
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-annotations</artifactId>
@@ -102,7 +117,7 @@
           <groupId>com.fasterxml.jackson.core</groupId>
           <artifactId>jackson-databind</artifactId>
         </exclusion>
-      </exclusions>
+      </exclusions-->
     </dependency>
     <dependency>
       <groupId>io.jenkins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins.workflow</groupId>
       <artifactId>workflow-aggregator</artifactId>
-      <version>${workflow.version}</version>
+      <version>600.v64c23868a_132</version>
       <scope>test</scope>
       <exclusions>
         <exclusion>


### PR DESCRIPTION
This PR updates pom with following 

1. ` org.jenkins-ci.plugins  from 4.69 --> 4.83  `
2.  `jenkins.version from 2.387.3 --> 2.452.2`
3. `hpi.compatibleSinceVersion from 2.0.0 --> 3.55`
4. `jackson.version from 2.14.0 --> 2.17.1`
5. `bom.version from bom-2.387.x --> bom-2.452.x`
6. `dsm.version to latest release 4.29.2426`
and other dsm dependent plugins


This is tested against jenkins version 2.452.2 with java 17 and dsm-secrets-jenkins-plugin  working fine

![image](https://github.com/fortanix/dsm-secrets-jenkins-plugin/assets/48242420/f9493dd8-414c-4224-a3a7-473c2a18e036)


you can see in above snapshot plugin is working fine

@Birajendu @uddhav-dave 