### PR TITLE
Adding support for Kubernetes Credentials Provider Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Fortanix Data Security Manager Secrets for Jenkins CI-CD
 
-This Jenkins Plugin allows you to access and retrieve secrets (and keys) 
+This Jenkins Plugin allows you to access and retrieve secrets (and keys)
 from Fortanix Data Security Manager for use in build environments.
 
 ## Usage
@@ -13,7 +13,7 @@ or label (name) of a secret (or exportable key).
 
 ![build-configuration](images/jenkins-build-config.jpg)
 
-This configuration specifies the `API Endpoint` of Fortanix DSM 
+This configuration specifies the `API Endpoint` of Fortanix DSM
 server (or service) containing those secrets.
 
 Additionally you will need to include a valid credential provider.
@@ -29,10 +29,10 @@ controls (RBAC) for projects authorized to access those secrets.
 This script also can be used on scripted pipelines using the **withCredentials** instruction.
 
 
-1.  With defaults, which will read specified **path** secret into the predefined environment variables: 
+1.  With defaults, which will read specified **path** secret into the predefined environment variables:
     `FTX_VAR`.
-    
-You just need to specify the `path` variable. 
+
+You just need to specify the `path` variable.
 
 
 Sample pipeline code:
@@ -55,6 +55,32 @@ Sample pipeline code:
  }
  ```
 NOTE: if path variable/ custom env variable not base64 encoded, then you can remove `| base64 -d` from echo statement.
+
+## Kubernetes Integration
+
+This plugin integrates with the [Kubernetes Credentials Provider Plugin](https://plugins.jenkins.io/kubernetes-credentials-provider/) to support automatic creation of Fortanix DSM credentials from Kubernetes secrets.
+
+### Prerequisites
+- Jenkins running in a Kubernetes cluster
+- [Kubernetes Credentials Provider Plugin](https://plugins.jenkins.io/kubernetes-credentials-provider/) installed in Jenkins
+
+### Usage
+
+1. Create a Kubernetes secret with the following format:
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: fortanix-credentials
+  annotations:
+    jenkins.io/credentials-description: "Fortanix DSM Credentials"
+  labels:
+    jenkins.io/credentials-type: "com.fortanix.jenkins.credentials.ClientCredentials"
+type: Opaque
+data:
+  apiKey: <base64-encoded-api-key>
+  apiEndpoint: <base64-encoded-api-endpoint>
+
 
 ## Release notes
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ type: Opaque
 data:
   apiKey: <base64-encoded-api-key>
   apiEndpoint: <base64-encoded-api-endpoint>
+```
 
 
 ## Release notes

--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
     <assert.version>3.11.1</assert.version>
     <bom.version>3135.v6d6c1f6b_3572</bom.version>
     <workflow.version>2.5</workflow.version>
+
+    <kubernetes-credentials-provider.version>1.262.v2670ef7ea_0c5</kubernetes-credentials-provider.version>
   </properties>
 
   <dependencyManagement>
@@ -195,6 +197,12 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>com.cloudbees.jenkins.plugins</groupId>
+      <artifactId>kubernetes-credentials-provider</artifactId>
+      <version>${kubernetes-credentials-provider.version}</version>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
 
   <repositories>
@@ -221,6 +229,16 @@
             <checkModificationExclude>pom.xml,.gitignore,LICENSE,README.md</checkModificationExclude>
           </checkModificationExcludes>
         </configuration>
+      </plugin>
+      <plugin>
+          <groupId>org.jenkins-ci.tools</groupId>
+          <artifactId>maven-hpi-plugin</artifactId>
+          <configuration>
+              <pluginFirstClassLoader>true</pluginFirstClassLoader>
+              <manifestEntries>
+                  <Plugin-Dependencies>kubernetes-credentials-provider:${kubernetes-credentials-provider.version};resolution:=optional</Plugin-Dependencies>
+              </manifestEntries>
+          </configuration>
       </plugin>
     </plugins>
   </build>

--- a/src/main/java/com/fortanix/jenkins/credentials/KubernetesCredentialConverter.java
+++ b/src/main/java/com/fortanix/jenkins/credentials/KubernetesCredentialConverter.java
@@ -1,0 +1,118 @@
+package com.fortanix.jenkins.credentials;
+
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.CredentialsConvertionException;
+import com.cloudbees.jenkins.plugins.kubernetes_credentials_provider.SecretToCredentialConverter;
+import hudson.Extension;
+import io.fabric8.kubernetes.api.model.Secret;
+import com.cloudbees.plugins.credentials.CredentialsScope;
+import java.util.Base64;
+import java.util.Map;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Converts Kubernetes secrets to Fortanix DSM credentials.
+ * This converter integrates with the Kubernetes Credentials Provider Plugin to enable
+ * automatic creation of Fortanix credentials from Kubernetes secrets.
+ *
+ * Requires the Kubernetes Credentials Provider Plugin to be installed:
+ * https://plugins.jenkins.io/kubernetes-credentials-provider/
+ *
+ * Example secret format:
+ * <pre>
+ * apiVersion: v1
+ * kind: Secret
+ * metadata:
+ *   name: fortanix-credentials
+ *   annotations:
+ *     jenkins.io/credentials-description: "Fortanix DSM Credentials"
+ *   labels:
+ *     jenkins.io/credentials-type: "com.fortanix.jenkins.credentials.ClientCredentials"
+ * type: Opaque
+ * data:
+ *   apiKey: <base64-encoded-api-key>
+ *   apiEndpoint: <base64-encoded-api-endpoint>
+ * </pre>
+ *
+ * @see ClientCredentials
+ * @see SecretToCredentialConverter
+ * @see <a href="https://plugins.jenkins.io/kubernetes-credentials-provider/">Kubernetes Credentials Provider Plugin</a>
+ */
+@Extension(optional = true)
+public class KubernetesCredentialConverter extends SecretToCredentialConverter {
+    private static final Logger LOGGER = Logger.getLogger(KubernetesCredentialConverter.class.getName());
+    private static final String CREDENTIALS_TYPE = "com.fortanix.jenkins.credentials.ClientCredentials";
+    private static final String API_KEY_FIELD = "apiKey";
+    private static final String API_ENDPOINT_FIELD = "apiEndpoint";
+    private static final String DESCRIPTION_ANNOTATION = "jenkins.io/credentials-description";
+
+    /**
+     * Checks if this converter can handle the given credential type.
+     * This method is called by the Kubernetes Credentials Provider Plugin to determine
+     * if this converter should handle a particular secret.
+     *
+     * @param type The fully qualified class name of the credential type
+     * @return true if this converter can handle the credential type
+     */
+    @Override
+    public boolean canConvert(String type) {
+        LOGGER.log(Level.FINE, "Checking if can convert type: {0}", type);
+        return CREDENTIALS_TYPE.equals(type);
+    }
+
+    /**
+     * Converts a Kubernetes Secret into a Fortanix ClientCredentials object.
+     * This method is called by the Kubernetes Credentials Provider Plugin when a secret
+     * with the matching type is found in the Kubernetes cluster.
+     *
+     * @param secret The Kubernetes Secret to convert
+     * @return A new ClientCredentials instance
+     * @throws CredentialsConvertionException if the conversion fails
+     */
+    @Override
+    public ClientCredentials convert(Secret secret) throws CredentialsConvertionException {
+        if (secret == null || secret.getMetadata() == null) {
+            throw new CredentialsConvertionException("Secret or its metadata is null");
+        }
+
+        String secretName = secret.getMetadata().getName();
+        LOGGER.log(Level.FINE, "Converting secret: {0}", secretName);
+
+        try {
+            String id = secretName;
+            Map<String, String> annotations = secret.getMetadata().getAnnotations();
+            String description = annotations != null ? annotations.get(DESCRIPTION_ANNOTATION) : "";
+
+            Map<String, String> data = secret.getData();
+            if (data == null) {
+                throw new CredentialsConvertionException("Secret data is null for secret: " + secretName);
+            }
+
+            // Get apiKey
+            String apiKeyBase64 = Optional.ofNullable(data.get(API_KEY_FIELD))
+                    .orElseThrow(() -> new CredentialsConvertionException(
+                            String.format("No %s found in secret: %s", API_KEY_FIELD, secretName)));
+            String apiKey = new String(Base64.getDecoder().decode(apiKeyBase64));
+
+            // Get apiEndpoint
+            String apiEndpointBase64 = Optional.ofNullable(data.get(API_ENDPOINT_FIELD))
+                    .orElseThrow(() -> new CredentialsConvertionException(
+                            String.format("No %s found in secret: %s", API_ENDPOINT_FIELD, secretName)));
+            String apiEndpoint = new String(Base64.getDecoder().decode(apiEndpointBase64));
+
+            LOGGER.log(Level.FINE, "Successfully converted secret: {0}", secretName);
+            return new ClientCredentials(CredentialsScope.GLOBAL,
+                                       id,
+                                       description,
+                                       apiEndpoint,
+                                       hudson.util.Secret.fromString(apiKey));
+        } catch (IllegalArgumentException e) {
+            LOGGER.log(Level.WARNING, "Invalid base64 encoding in secret: {0}", secretName);
+            throw new CredentialsConvertionException("Invalid base64 encoding in secret: " + e.getMessage());
+        } catch (Exception e) {
+            LOGGER.log(Level.WARNING, "Failed to convert secret: {0}", e.getMessage());
+            throw new CredentialsConvertionException("Failed to convert credentials: " + e.getMessage());
+        }
+    }
+}

--- a/src/main/java/com/fortanix/jenkins/credentials/KubernetesCredentialConverter.java
+++ b/src/main/java/com/fortanix/jenkins/credentials/KubernetesCredentialConverter.java
@@ -79,31 +79,30 @@ public class KubernetesCredentialConverter extends SecretToCredentialConverter {
         String secretName = secret.getMetadata().getName();
         LOGGER.log(Level.FINE, "Converting secret: {0}", secretName);
 
-        try {
-            String id = secretName;
-            Map<String, String> annotations = secret.getMetadata().getAnnotations();
-            String description = annotations != null ? annotations.get(DESCRIPTION_ANNOTATION) : "";
+        Map<String, String> data = secret.getData();
+        if (data == null) {
+            throw new CredentialsConvertionException("Secret data is null for secret: " + secretName);
+        }
 
-            Map<String, String> data = secret.getData();
-            if (data == null) {
-                throw new CredentialsConvertionException("Secret data is null for secret: " + secretName);
-            }
+        try {
+            Map<String, String> annotations = secret.getMetadata().getAnnotations();
+            String description = (annotations != null && annotations.containsKey(DESCRIPTION_ANNOTATION)) ? annotations.get(DESCRIPTION_ANNOTATION) : "";
 
             // Get apiKey
-            String apiKeyBase64 = Optional.ofNullable(data.get(API_KEY_FIELD))
+            String apiKey = Optional.ofNullable(data.get(API_KEY_FIELD))
+                    .map(key -> new String(Base64.getDecoder().decode(key)))
                     .orElseThrow(() -> new CredentialsConvertionException(
                             String.format("No %s found in secret: %s", API_KEY_FIELD, secretName)));
-            String apiKey = new String(Base64.getDecoder().decode(apiKeyBase64));
 
             // Get apiEndpoint
-            String apiEndpointBase64 = Optional.ofNullable(data.get(API_ENDPOINT_FIELD))
+            String apiEndpoint = Optional.ofNullable(data.get(API_ENDPOINT_FIELD))
+                    .map(endpoint -> new String(Base64.getDecoder().decode(endpoint)))
                     .orElseThrow(() -> new CredentialsConvertionException(
                             String.format("No %s found in secret: %s", API_ENDPOINT_FIELD, secretName)));
-            String apiEndpoint = new String(Base64.getDecoder().decode(apiEndpointBase64));
 
             LOGGER.log(Level.FINE, "Successfully converted secret: {0}", secretName);
             return new ClientCredentials(CredentialsScope.GLOBAL,
-                                       id,
+                                       secretName,
                                        description,
                                        apiEndpoint,
                                        hudson.util.Secret.fromString(apiKey));


### PR DESCRIPTION
# Add Kubernetes Credentials Provider Support

This PR adds support for the [Kubernetes Credentials Provider Plugin](https://plugins.jenkins.io/kubernetes-credentials-provider/), allowing Fortanix DSM credentials to be automatically created from Kubernetes secrets.

## Changes
- Added `KubernetesCredentialConverter` to convert Kubernetes secrets to Fortanix credentials
- Updated dependencies to include Kubernetes Credentials Provider Plugin
- Added documentation for Kubernetes integration

## Example Usage
Create a Kubernetes secret with the following format:
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: fortanix-credentials
  annotations:
    jenkins.io/credentials-description: "Fortanix DSM Credentials"
  labels:
    jenkins.io/credentials-type: "com.fortanix.jenkins.credentials.ClientCredentials"
type: Opaque
data:
  apiKey: <base64-encoded-api-key>
  apiEndpoint: <base64-encoded-api-endpoint>
```

## Requirements
- Jenkins running in a Kubernetes cluster
- [Kubernetes Credentials Provider Plugin](https://plugins.jenkins.io/kubernetes-credentials-provider/) installed in Jenkins

## Testing Done
- Verified credential creation from Kubernetes secrets
- Tested with both valid and invalid secret formats
- Confirmed proper error handling and logging